### PR TITLE
Add password input for API token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ __pycache__/
 build/
 dist/
 *.egg-info/
+
+# Virtual environments
+.env
+.venv
+
+.easeldb

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For each of these operations, refer to their detailed description and usage
 below.
 
 1. Tell easel about your Canvas instance (only needs to be run once):
-    `easel login <canvas_base_url> <api_token>`
+    `easel login <canvas_base_url>`
 2. Initialize easel in a course-specific directory: `easel init`
 3. Add a course or courses (i.e., sections):
     `easel course add <canvas_course_url>`

--- a/easel/__main__.py
+++ b/easel/__main__.py
@@ -30,7 +30,7 @@ def main():
     parser_login = subparsers.add_parser("login", help="login to Canvas")
     parser_login.add_argument("hostname", help="the hostname of your Canvas "
             "instance")
-    parser_login.add_argument("token", help="your api token")
+    parser_login.add_argument("--token", help="your api token")
     parser_login.set_defaults(func=commands.cmd_login)
 
     ## init

--- a/easel/commands.py
+++ b/easel/commands.py
@@ -1,3 +1,4 @@
+import getpass
 import importlib
 import logging
 import os.path
@@ -13,6 +14,8 @@ from easel import navigation_tab
 def cmd_login(db, args):
     hostname = args.hostname
     token = args.token
+    if not token:
+        token = getpass.getpass("Enter your API token: ")
 
     protocol = "https://"
     if hostname.startswith(protocol):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-markdown==3.3.4
-pygments==2.11.2
+markdown
+pygments
+python-dotenv
 pyyaml
 requests
 tinydb


### PR DESCRIPTION
This adds the option to not paste in your API token in the command directly. If you don't add `--token <token>`, it asks for the token via password prompt.